### PR TITLE
remove service status "feature"

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -16,10 +16,6 @@ Admin interface screenshots
 
    Managing email domains
 
-.. figure:: assets/screenshots/status.png
-
-   Displaying service status
-
 .. figure:: assets/screenshots/token.png
 
    Creating an authentication token


### PR DESCRIPTION
Per the issue tracker, this was removed in issue #463 (Remove the Service Status page)

## What type of PR?

documentation

## What does this PR do?

remove feature for services status which no longer exists; this confused me as I was trying to find it and was not able to.

### Related issue(s)
- Remove the Service Status page #463

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

